### PR TITLE
update from pinned nightly rustc to unpinned stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ Cargo.lock
 one-life/
 pkg/
 node_modules/
+
+# Ignore Visual Studio Code
+.vscode/
+
+# Ignore Trunk
+.trunk/
+
+# Ignore MacOS files
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,11 @@ serbia = "0.4.3"
 # allocator, so it's not enabled by default.
 wee_alloc = { version = "0.4.2", optional = true }
 
+# `variant_count` is a crate that replaces the unstable/nightly feature
+# `std::mem::variant_count` with a macro achieving similar results, but with
+# different syntax.
+variant_count = "1.1"
+
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.
 [dependencies.web-sys]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Setup
 
-The setup is based on [this tutorial](https://rustwasm.github.io/docs/wasm-pack/prerequisites/index.html), but an excerp follows below.
+The setup is based on
+[this tutorial](https://rustwasm.github.io/docs/wasm-pack/prerequisites/index.html),
+but an excerpt follows below.
 
 Install rust and then wasm-pack:
 
@@ -10,37 +12,36 @@ Install rust and then wasm-pack:
 curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 ```
 
-install [nvm](https://github.com/nvm-sh/nvm):
+Install [nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-follow any extra instructions from the script and restart your terminal. Then run:
+Follow any extra instructions from the script and restart your terminal. Then run:
 
 ```bash
-nvm install 16
+nvm install v16.13.2
 nvm use
 ```
-you don't need to specify 16 since it's set by the .nvmrc file
 
-install npm and then run:
+You don't need to specify the version since it is set by the `.nvmrc` file.
+
+Install npm and then run:
 
 ```bash
 npm install
 ```
 
-Then run:
+To start a web server that auto-reloads on changes, run:
 
 ```bash
 npm start
 ```
 
-To start a webserver that auto-reloads on changes.
-
 ## Test Release version
 
-run
+Run:
 
 ```bash
 npm run-script build
@@ -48,16 +49,17 @@ cd dist
 python3.8 -m http.server 8000
 ```
 
-Note that you need quite a new server (python 3.8 for example) or the mime type won't be correct for the wasm content
+Note that you need quite a new server (python 3.8 for example)
+or the mime type won't be correct for the wasm content.
 
 ## Release version
 
-We release by pushing to the github pages branch with the help of a npm package:
-https://www.npmjs.com/package/gh-pages
+We release by pushing to the github pages branch with the help of the
+[gh-pages](https://www.npmjs.com/package/gh-pages) package.
 
 To publish/deploy run:
 
-```
+```bash
 npm run deploy
 ```
 
@@ -65,9 +67,9 @@ npm run deploy
 
 ### Easy way
 
-Run all tests
+Run all tests:
 
-```
+```bash
 WASM_BINDGEN_TEST_TIMEOUT=60 wasm-pack test --node
 ```
 
@@ -81,26 +83,30 @@ WASM_BINDGEN_TEST_TIMEOUT=60 wasm-pack test --node --test tier_0
 
 Install:
 
-```
+```bash
 cargo install wasm-bindgen-cli
 ```
 
 Run with:
 
-```
+```bash
 WASM_BINDGEN_TEST_TIMEOUT=60 cargo test --target wasm32-unknown-unknown
 ```
 
 ## Code Standards
 
-We use [prettier](https://prettier.io/) for formating, please run the following before commiting.
+We use [prettier](https://prettier.io/) for formatting.
+Please run the following before committing:
 
-```
+```bash
 npx prettier --write .
 ```
 
-Or a faster version
+Or a faster version:
 
-```
-npx prettier $(git diff --name-only --diff-filter=ACM) $(git diff --cached --name-only --diff-filter=ACM) --write --ignore-unknown
+```bash
+npx prettier \
+    $(git diff --name-only --diff-filter=ACM) \
+    $(git diff --cached --name-only --diff-filter=ACM) \
+    --write --ignore-unknown
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-26"
-components = [ "rustfmt", "clippy" ]
+channel = "stable"
+components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/engine/auto_functions.rs
+++ b/src/engine/auto_functions.rs
@@ -1,6 +1,9 @@
 use crate::{
-    game::Game, input::options::AutoSettingTypes, world_content::boost_item::translate_boost_item,
-    world_content::tomb::translate_tomb, WORLD,
+    game::Game,
+    input::{boost_item::BoostItemTypes, options::AutoSettingTypes},
+    world_content::boost_item::translate_boost_item,
+    world_content::tomb::translate_tomb,
+    WORLD,
 };
 
 pub fn auto_work(game: &mut Game) {
@@ -61,7 +64,7 @@ pub fn auto_buy_queued_item(game: &mut Game) {
     }
     game.input
         .item_queue
-        .drain_filter(|item_type| game.state.boost_items[*item_type as usize].is_purchased);
+        .retain(|item_type| !game.state.boost_items[*item_type as usize].is_purchased);
 }
 
 pub fn auto_buy_tomb(game: &mut Game) {

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,9 +1,11 @@
+extern crate variant_count;
+
 use super::game::Game;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
 use strum::IntoEnumIterator;
+use variant_count::VariantCount;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Info {
@@ -39,7 +41,16 @@ fn should_show_tutorial() -> bool {
 }
 
 #[derive(
-    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, FromPrimitive,
+    Serialize,
+    Deserialize,
+    EnumIter,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    FromPrimitive,
+    VariantCount,
 )]
 pub enum TutorialStep {
     Welcome,
@@ -51,7 +62,7 @@ pub enum TutorialStep {
     SafeGuard,
 }
 
-pub const TUTORIAL_STEP_SIZE: usize = variant_count::<TutorialStep>();
+pub const TUTORIAL_STEP_SIZE: usize = TutorialStep::VARIANT_COUNT;
 
 impl TutorialStep {
     pub fn increment(&mut self) {

--- a/src/input/activity.rs
+++ b/src/input/activity.rs
@@ -1,10 +1,14 @@
+extern crate variant_count;
+
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
 use super::Recordable;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum ActivityTypes {
     //Stat boosts
     Run,
@@ -18,7 +22,7 @@ pub enum ActivityTypes {
     WarGames,
 }
 
-pub const ACTIVITY_SIZE: usize = variant_count::<ActivityTypes>();
+pub const ACTIVITY_SIZE: usize = ActivityTypes::VARIANT_COUNT;
 
 impl Recordable for ActivityTypes {
     fn to_record_key(&self) -> String {

--- a/src/input/blessing.rs
+++ b/src/input/blessing.rs
@@ -1,10 +1,14 @@
+extern crate variant_count;
+
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
 use super::Recordable;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum BlessingTypes {
     HeruclesStrength,
     AthenasWisdom,
@@ -12,7 +16,7 @@ pub enum BlessingTypes {
     PoseidonsSturdiness,
 }
 
-pub const BLESSING_SIZE: usize = variant_count::<BlessingTypes>();
+pub const BLESSING_SIZE: usize = BlessingTypes::VARIANT_COUNT;
 
 impl Recordable for BlessingTypes {
     fn to_record_key(&self) -> String {

--- a/src/input/boost_item.rs
+++ b/src/input/boost_item.rs
@@ -1,10 +1,14 @@
+extern crate variant_count;
+
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
 use super::Recordable;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum BoostItemTypes {
     Book,
     Shoe1,
@@ -59,7 +63,7 @@ pub enum BoostItemTypes {
     Clothes6,
 }
 
-pub const BOOST_ITEM_SIZE: usize = variant_count::<BoostItemTypes>();
+pub const BOOST_ITEM_SIZE: usize = BoostItemTypes::VARIANT_COUNT;
 
 impl Recordable for BoostItemTypes {
     fn to_record_key(&self) -> String {

--- a/src/input/housing.rs
+++ b/src/input/housing.rs
@@ -1,9 +1,13 @@
+extern crate variant_count;
+
 use super::Recordable;
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum HousingTypes {
     StoneFloor,
     ComfortableSpot,
@@ -17,7 +21,7 @@ pub enum HousingTypes {
     Appartment,
 }
 
-pub const HOUSING_SIZE: usize = variant_count::<HousingTypes>();
+pub const HOUSING_SIZE: usize = HousingTypes::VARIANT_COUNT;
 
 impl Recordable for HousingTypes {
     fn to_record_key(&self) -> String {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -42,7 +42,7 @@ impl Input {
     }
 
     pub fn dequeue_item(&mut self, item: BoostItemTypes) {
-        self.item_queue.drain_filter(|item_type| *item_type == item);
+        self.item_queue.retain(|item_type| *item_type != item);
     }
 
     pub fn queue_item(&mut self, item: BoostItemTypes) {

--- a/src/input/rebirth_upgrade.rs
+++ b/src/input/rebirth_upgrade.rs
@@ -1,8 +1,12 @@
-use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
-use strum::EnumIter;
+extern crate variant_count;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+use variant_count::VariantCount;
+
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum RebirthUpgradeTypes {
     AcceptingDeath,
     AcceptingDeath2,
@@ -42,7 +46,7 @@ pub enum RebirthUpgradeTypes {
     GemKnowledge,
 }
 
-pub const REBIRTH_UPGRADE_SIZE: usize = variant_count::<RebirthUpgradeTypes>();
+pub const REBIRTH_UPGRADE_SIZE: usize = RebirthUpgradeTypes::VARIANT_COUNT;
 
 // impl Recordable for RebirthUpgradeTypes {
 //     fn to_record_key(&self) -> String {

--- a/src/input/skill.rs
+++ b/src/input/skill.rs
@@ -1,11 +1,15 @@
-use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
-use strum::EnumIter;
+extern crate variant_count;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+use variant_count::VariantCount;
+
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum SkillTypes {
     Mindfull,
     Tactics,
 }
 
-pub const SKILL_SIZE: usize = variant_count::<SkillTypes>();
+pub const SKILL_SIZE: usize = SkillTypes::VARIANT_COUNT;

--- a/src/input/stat.rs
+++ b/src/input/stat.rs
@@ -1,9 +1,13 @@
+extern crate variant_count;
+
 use crate::input::work::WorkCategoryTypes;
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum StatTypes {
     Con,
     Int,
@@ -24,4 +28,4 @@ impl From<WorkCategoryTypes> for StatTypes {
     }
 }
 
-pub const STAT_SIZE: usize = variant_count::<StatTypes>();
+pub const STAT_SIZE: usize = StatTypes::VARIANT_COUNT;

--- a/src/input/tomb.rs
+++ b/src/input/tomb.rs
@@ -1,10 +1,14 @@
+extern crate variant_count;
+
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
 use super::Recordable;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum TombTypes {
     ShallowGrave,
     BurialPit,
@@ -16,7 +20,7 @@ pub enum TombTypes {
     Catacomb,
 }
 
-pub const TOMB_SIZE: usize = variant_count::<TombTypes>();
+pub const TOMB_SIZE: usize = TombTypes::VARIANT_COUNT;
 
 impl Recordable for TombTypes {
     fn to_record_key(&self) -> String {

--- a/src/input/work.rs
+++ b/src/input/work.rs
@@ -1,9 +1,13 @@
+extern crate variant_count;
+
 use super::{stat::StatTypes, Recordable};
 use serde::{Deserialize, Serialize};
-use std::mem::variant_count;
 use strum::EnumIter;
+use variant_count::VariantCount;
 
-#[derive(Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Serialize, Deserialize, EnumIter, Clone, Copy, Debug, PartialEq, PartialOrd, VariantCount,
+)]
 pub enum WorkTypes {
     // Worker Types
     Mines,
@@ -67,7 +71,7 @@ impl TryFrom<StatTypes> for WorkCategoryTypes {
     }
 }
 
-pub const WORK_SIZE: usize = variant_count::<WorkTypes>();
+pub const WORK_SIZE: usize = WorkTypes::VARIANT_COUNT;
 
 impl Recordable for WorkTypes {
     fn to_record_key(&self) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-#![feature(variant_count)]
-#![feature(drain_filter)]
 #![allow(non_upper_case_globals)]
-// #![feature(generic_const_exprs)]
 
 use icon::{Icon, IconType};
 use input_recording::{Inputs, RecordedInputEntry};

--- a/src/world_content/work.rs
+++ b/src/world_content/work.rs
@@ -72,7 +72,7 @@ const fn translate_work(work: WorkTypes) -> Work {
             name: work,
             money: 2.5,
             description: "Row row row your boat",
-            display_name: "Gallery Rower",
+            display_name: "Galley Rower",
             required_tier: 0,
             work_type: WorkCategoryTypes::Labor,
             xp_req_modifier: 4.0,


### PR DESCRIPTION
- switch rust-toolchain from pinned nightly to unpinned stable
- remove nightly features from lib.rs
- drain_filter: use vec.retain in place of nightly drain_filter feature
- variant_count:
  - add variant_count crate to Cargo.toml
  - use variant_count::VariantCount in place of nightly feature

Also:
- add to gitignore: vscode, trunk, MacOS
- one typo fix: "Gallery" -> "Galley"
- edited readme
  - add language notations to all code-blocks
  - consistent capitalization
  - a few typo fixes
  - update nvm version reference
  - other minor edits

Code compiles & passes tests.