### PR TITLE
issue #13, fix "debug_assertions" in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,15 @@ name = "one_life"
 # so it's only enabled in release mode.
 lto = true
 
+[features]
+default = ["console_error_panic_hook"]
+
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 num-traits = "0.2"
 num-derive = "0.4.0"
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -38,6 +41,12 @@ lazy_static = "1.4.0"
 anyhow = "1.0.52"
 # serde-big-array = "0.3.2"
 serbia = "0.4.3"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.1", optional = true }
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. However, it is slower than the default
@@ -55,12 +64,14 @@ variant_count = "1.1"
 version = "0.3.22"
 features = ["console", "Storage", "Window"]
 
+# TODO: delete this block, below
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so it's only enabled
 # in debug mode.
-[target."cfg(debug_assertions)".dependencies]
-console_error_panic_hook = "0.1.5"
+# [target."cfg(debug_assertions)".dependencies]
+# console_error_panic_hook = "0.1.5"
+# TODO: delete this block, above
 
 # These packages are used by the build script.
 [build-dependencies]
@@ -72,7 +83,6 @@ vergen = { version = "8.0.0", features = [
   "rustc",
   "si",
 ] }
-
 
 # These crates are used for running unit tests.
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ npm start
 Run:
 
 ```bash
-npm run-script build
-cd dist
-python3.8 -m http.server 8000
+npm run start:dist
 ```
 
-Note that you need quite a new server (python 3.8 for example)
-or the mime type won't be correct for the wasm content.
+Note that you need Python 3.8 (2019 release) or newer,
+else the mime type won't be correct for the wasm content.
 
 ## Release version
 

--- a/build.rs
+++ b/build.rs
@@ -3,11 +3,11 @@ use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Emit the instructions
-    // EmitBuilder::builder().emit()?;
     EmitBuilder::builder()
-        .all_build()
-        .all_rustc()
-        .all_git()
-        .emit_and_set()?;
+        // each of the following three methods prepares a set of VERGEN environment variables
+        .all_build() // prepares the "VERGEN_BUILD_*" environment variables
+        .all_rustc() // prepares the "VERGEN_RUSTC_*" environment variables
+        .all_git() // prepares the "VERGEN_GIT_*" environment variables
+        .emit_and_set()?; // actually sets the environment variables
     Ok(())
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
-    "postdeploy": "rimraf dist",
-    "build": "rimraf dist pkg && webpack",
-    "start": "rimraf dist pkg && webpack-dev-server --open -d",
+    "postdeploy": "npm run clean",
+    "clean": "rimraf dist pkg",
+    "build": "npm run clean && webpack",
+    "start": "npm run clean && webpack-dev-server --open -d",
+    "start:dist": "npm run build && python3 -m http.server 8000 --directory dist",
     "test": "cargo test && wasm-pack test --headless",
     "test:node": "WASM_BINDGEN_TEST_TIMEOUT=60 wasm-pack test --node",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix js"

--- a/src/info.rs
+++ b/src/info.rs
@@ -33,7 +33,6 @@ impl Info {
         let commit_hash: String = option_env!("VERGEN_RUSTC_COMMIT_HASH")
             .unwrap_or("abc123xyz789")
             .chars()
-            .into_iter()
             .take(7)
             .collect();
         let commit_date: String = option_env!("VERGEN_GIT_COMMIT_DATE")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,15 +62,26 @@ lazy_static! {
 #[wasm_bindgen(start)]
 pub fn main_js() -> Result<(), JsValue> {
     console_log::init_with_level(Level::Info).expect("error initializing log");
+
     // This provides better error messages in debug mode.
     // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(debug_assertions)]
-    console_error_panic_hook::set_once();
+    set_panic_hook();
 
     // Your code goes here!
     info!("Hello One Life!");
 
     Ok(())
+}
+
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
 }
 
 #[wasm_bindgen]

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -2,14 +2,16 @@ use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+const X: i32 = 1;
+
 // This runs a unit test in native Rust, so it can only use Rust APIs.
 #[test]
 fn rust_test() {
-    assert_eq!(1, 1);
+    assert_eq!(X, 1);
 }
 
 // This runs a unit test in the browser, so it can use browser APIs.
 #[wasm_bindgen_test]
 fn web_test() {
-    assert_eq!(1, 1);
+    assert_eq!(X, 1);
 }


### PR DESCRIPTION
Update Cargo.toml & src/lib.rs to reflect new guidance on implementing console_error_panic_hook. Changes were tested by:
  - npm run start
  - visual confirmation that dev site still has debug
  - npm run start:dist
  - visual confirmation that dist site does NOT have debug

Also:
- add scripts to package.json
  - start:dist ...& ref in readme
  - clean ...& use it in other npm scripts
- tidy build.rs & add comments
- edit readme: npm run-script -> npm run
- minor edit to test, to appease rust-analyzer
- fix clippy warning in info.rs